### PR TITLE
Fix PetFrame ADDON_ACTION_BLOCKED taint in combat

### DIFF
--- a/midnight/modules/hideFrames.lua
+++ b/midnight/modules/hideFrames.lua
@@ -170,13 +170,14 @@ function BBF.HideFrames()
         FocusFrame.TargetFrameContent.TargetFrameContentContextual.PrestigePortrait:SetAlpha(prestigeBadgeAlpha)
 
         -- Hide Pet Frame
+        -- Avoid hideElementByParent (SetParent) on PetFrame as it taints the
+        -- protected frame, causing ADDON_ACTION_BLOCKED on ClearAllPointsBase
+        -- when Blizzard's managed-frame system repositions PetFrame during combat.
         if BetterBlizzFramesDB.hidePetFrame then
-            hideElementByParent(PetFrame)
             PetFrame:SetAlpha(0)
             PetFrame:EnableMouse(false)
             changes.hidePetFrame = true
         elseif changes.hidePetFrame then
-            restoreElementParent(PetFrame)
             PetFrame:SetAlpha(1)
             PetFrame:EnableMouse(true)
             changes.hidePetFrame = nil

--- a/retail/modules/hideFrames.lua
+++ b/retail/modules/hideFrames.lua
@@ -167,10 +167,17 @@ function BBF.HideFrames()
         FocusFrame.TargetFrameContent.TargetFrameContentContextual.PrestigePortrait:SetAlpha(prestigeBadgeAlpha)
 
         -- Hide Pet Frame
+        -- Avoid hideElementByParent (SetParent) on PetFrame as it taints the
+        -- protected frame, causing ADDON_ACTION_BLOCKED on ClearAllPointsBase
+        -- when Blizzard's managed-frame system repositions PetFrame during combat.
         if BetterBlizzFramesDB.hidePetFrame then
-            hideElementByParent(PetFrame)
-        else
-            restoreElementParent(PetFrame)
+            PetFrame:SetAlpha(0)
+            PetFrame:EnableMouse(false)
+            changes.hidePetFrame = true
+        elseif changes.hidePetFrame then
+            PetFrame:SetAlpha(1)
+            PetFrame:EnableMouse(true)
+            changes.hidePetFrame = nil
         end
 
         -- Hide reputation color on target frame (color tint behind name)


### PR DESCRIPTION
## Summary

- `hideElementByParent()` calls `SetParent()` on PetFrame, which taints the protected unit frame
- When Blizzard's managed-frame system later repositions PetFrame during combat (via `UpdateShownState` → `AddManagedFrame` → `ClearAllPoints`), the tainted `ClearAllPointsBase()` call is blocked
- Replace `SetParent`-based hiding with `SetAlpha(0)` / `EnableMouse(false)` which effectively hides PetFrame without tainting its protected methods

## Error

```
[ADDON_ACTION_BLOCKED] AddOn 'BetterBlizzFrames' tried to call the protected function 'PetFrame:ClearAllPointsBase()'.
```

Stack trace:
```
[C]: in function 'ClearAllPointsBase'
Blizzard_EditMode/.../EditModeSystemTemplates.lua:154: in function 'ClearAllPoints'
Blizzard_UIParent/.../UIParent.lua:152: in function 'UpdateFrame'
Blizzard_UIParent/.../UIParent.lua:183: in function 'AddManagedFrame'
Blizzard_UIParent/.../UIParent.lua:121: in function 'OnShow'
Blizzard_UnitFrame/.../PetFrame.lua:126
```

## Changes

- **midnight/modules/hideFrames.lua**: Remove `hideElementByParent(PetFrame)` and `restoreElementParent(PetFrame)` calls, keep existing `SetAlpha`/`EnableMouse` calls
- **retail/modules/hideFrames.lua**: Replace `hideElementByParent(PetFrame)` / `restoreElementParent(PetFrame)` with `SetAlpha(0)`/`EnableMouse(false)` approach (matching midnight)

The midnight path already used `SetAlpha(0)` and `EnableMouse(false)` alongside `SetParent` — this just removes the `SetParent` calls that cause taint. The retail path is updated to match.

## Test plan

- [ ] Enable "Hide Pet Frame" in BBF settings
- [ ] Summon a pet and enter combat — no ADDON_ACTION_BLOCKED errors
- [ ] Toggle the setting off — PetFrame reappears correctly
- [ ] Verify PetFrame stays hidden through combat/zone transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)