### PR TITLE
Fix party/pet castbar reset buttons and missing checkboxes

### DIFF
--- a/temp_cata/BetterBlizzFrames.lua
+++ b/temp_cata/BetterBlizzFrames.lua
@@ -126,7 +126,7 @@ local defaultSettings = {
     petCastBarWidth = 137,
     petCastBarHeight = 10,
     showPetCastBarIcon = true,
-    showPetCastBarTimer = false,
+    petCastBarTimer = false,
     petCastBarShowText = true,
     petCastBarShowBorder = true,
 
@@ -174,7 +174,7 @@ local defaultSettings = {
     playerCastBarWidth = 195,
     playerCastBarHeight = 13,
     playerCastBarTimer = false,
-    playerCastBarTimerCenter = false,
+    playerCastBarTimerCentered = false,
     playerCastBarShowText = true,
     playerCastBarShowBorder = true,
 

--- a/temp_era/gui.lua
+++ b/temp_era/gui.lua
@@ -3867,7 +3867,7 @@ local function guiCastbars()
         BetterBlizzFramesDB.partyCastbarShowText = true
         BetterBlizzFramesDB.partyCastbarShowBorder = true
         BetterBlizzFramesDB.partyCastbarSelf = false
-        BBF.CastBarTimerCaller()
+        BBF.UpdateCastbars()
     end)
 
 
@@ -4153,7 +4153,7 @@ local function guiCastbars()
         BetterBlizzFramesDB.petCastBarShowBorder = true
         BetterBlizzFramesDB.petDetachCastbar = false
         BetterBlizzFramesDB.petCastBarTimer = true
-        BBF.CastBarTimerCaller()
+        BBF.UpdatePetCastbar()
     end)
 
    ----------------------

--- a/temp_era/gui.lua
+++ b/temp_era/gui.lua
@@ -4144,9 +4144,11 @@ local function guiCastbars()
         petCastBarWidth:SetValue(137)
         petCastBarHeight:SetValue(10)
         petCastBarTimer:SetChecked(true)
+        showPetCastBarIcon:SetChecked(true)
         petCastBarShowText:SetChecked(true)
         petCastBarShowBorder:SetChecked(true)
         petDetachCastbar:SetChecked(false)
+        BetterBlizzFramesDB.showPetCastBarIcon = true
         BetterBlizzFramesDB.petCastBarShowText = true
         BetterBlizzFramesDB.petCastBarShowBorder = true
         BetterBlizzFramesDB.petDetachCastbar = false

--- a/temp_era/gui.lua
+++ b/temp_era/gui.lua
@@ -3849,16 +3849,24 @@ local function guiCastbars()
         partyCastBarIconScale:SetMinMaxValues(0.4, 2)
         partyCastbarIconXPos:SetMinMaxValues(-50, 50)
         partyCastbarIconYPos:SetMinMaxValues(-50, 50)
-        partyCastBarScale:SetValue(1)
-        partyCastBarIconScale:SetValue(1)
+        partyCastBarScale:SetValue(0.9)
+        partyCastBarIconScale:SetValue(0.9)
         partyCastBarXPos:SetValue(0)
         partyCastBarYPos:SetValue(0)
         partyCastbarIconXPos:SetValue(0)
         partyCastbarIconYPos:SetValue(0)
-        partyCastBarWidth:SetValue(100)
-        partyCastBarHeight:SetValue(12)
+        partyCastBarWidth:SetValue(137)
+        partyCastBarHeight:SetValue(10)
         partyCastBarTimer:SetChecked(true)
+        showPartyCastBarIcon:SetChecked(true)
+        partyCastbarShowText:SetChecked(true)
+        partyCastbarShowBorder:SetChecked(true)
+        partyCastbarSelf:SetChecked(false)
         BetterBlizzFramesDB.partyCastBarTimer = true
+        BetterBlizzFramesDB.showPartyCastBarIcon = true
+        BetterBlizzFramesDB.partyCastbarShowText = true
+        BetterBlizzFramesDB.partyCastbarShowBorder = true
+        BetterBlizzFramesDB.partyCastbarSelf = false
         BBF.CastBarTimerCaller()
     end)
 


### PR DESCRIPTION
## Summary
- Fix party reset using wrong default values (scale 1 → 0.9, icon scale 1 → 0.9, width 100 → 137, height 12 → 10)
- Fix party reset not resetting text, border, icon, self checkboxes
- Fix pet reset not resetting icon checkbox
- Fix reset buttons calling no-op `CastBarTimerCaller()` instead of `UpdateCastbars()` / `UpdatePetCastbar()`
- Fix mismatched default setting keys: `showPetCastBarTimer` → `petCastBarTimer`, `playerCastBarTimerCenter` → `playerCastBarTimerCentered`

Note: The reset button previously used hardcoded slider values that didn't match the DB defaults. This changes the following reset values:

That can unintentionally "add" features by default thats not wanted. But then we should tweak the defaults :)

**Party castbar:**
Scale, icon scale, width and height
Icon, text, and border checkboxes now reset to enabled (previously not reset at all)
Self checkbox now resets to disabled

**Pet castbar:**
Scale, width and height
Icon checkbox now resets to enabled (previously not reset at all)

<img width="293" height="601" alt="image" src="https://github.com/user-attachments/assets/4f460a7b-03dd-43be-84f7-c03e0d586102" />

<img width="475" height="665" alt="image" src="https://github.com/user-attachments/assets/7ef04cd7-9c2c-4419-96f7-314f73610a7b" />



## Test plan
- [ ] Click party castbar Reset, verify sliders match DB defaults
- [ ] Click party castbar Reset, verify all checkboxes reset correctly
- [ ] Click pet castbar Reset, verify icon checkbox resets correctly
- [ ] Click party castbar Reset, verify castbar visually updates immediately
- [ ] Click pet castbar Reset, verify castbar visually updates immediately
- [ ] Fresh install: verify pet timer and player timer centered defaults apply correctly