### PR TITLE
Darken CompactPartyFrameMember borders in dark mode

### DIFF
--- a/temp_era/modules/darkmode.lua
+++ b/temp_era/modules/darkmode.lua
@@ -359,14 +359,16 @@ function BBF.DarkmodeFrames(bypass)
                 applySettings(region, desaturationValue, vertexColor)
             end
         end
-        for i = 1, 5 do
-            local frame = _G["CompactRaidFrame"..i]
-            if frame then
-                applySettings(frame.horizDivider, desaturationValue, vertexColor)
-                applySettings(frame.horizTopBorder, desaturationValue, vertexColor)
-                applySettings(frame.horizBottomBorder, desaturationValue, vertexColor)
-                applySettings(frame.vertLeftBorder, desaturationValue, vertexColor)
-                applySettings(frame.vertRightBorder, desaturationValue, vertexColor)
+        for i = 1, MEMBERS_PER_RAID_GROUP do
+            for _, prefix in ipairs({"CompactPartyFrameMember", "CompactRaidFrame"}) do
+                local frame = _G[prefix..i]
+                if frame then
+                    applySettings(frame.horizDivider, desaturationValue, vertexColor)
+                    applySettings(frame.horizTopBorder, desaturationValue, vertexColor)
+                    applySettings(frame.horizBottomBorder, desaturationValue, vertexColor)
+                    applySettings(frame.vertLeftBorder, desaturationValue, vertexColor)
+                    applySettings(frame.vertRightBorder, desaturationValue, vertexColor)
+                end
             end
         end
     end


### PR DESCRIPTION
## Summary
- Darken `CompactPartyFrameMember` borders in dark mode (previously only `CompactRaidFrame` borders were darkened)
- Use `MEMBERS_PER_RAID_GROUP` constant instead of hardcoded 5

<img width="381" height="663" alt="image" src="https://github.com/user-attachments/assets/d72ec012-1875-4f29-a3aa-61194b149ef2" />

<img width="420" height="634" alt="image" src="https://github.com/user-attachments/assets/6eb330a5-5f59-454e-ac9f-78b8797a2876" />

## Test plan
- [ ] Enable dark mode with compact party frames, verify horiz/vert borders are darkened