### PR TITLE
trp3 secret value error fixes

### DIFF
--- a/midnight/modules/healthbarColor.lua
+++ b/midnight/modules/healthbarColor.lua
@@ -55,6 +55,7 @@ end
 
 local function GetRPNameColor(unit)
     if not TRP3_API or not TRP3_API.globals or not TRP3_API.globals.player_realm_id then return end
+    if issecretvalue(UnitGUID(unit)) or issecretvalue(UnitName(unit)) then return end
     local player = AddOn_TotalRP3 and AddOn_TotalRP3.Player and AddOn_TotalRP3.Player.CreateFromUnit(unit)
     if player then
         local color = player:GetCustomColorForDisplay()

--- a/midnight/modules/nameFix.lua
+++ b/midnight/modules/nameFix.lua
@@ -93,6 +93,7 @@ local customColorPartyNames
 local function GetRPNameColor(unit)
     if not UnitExists(unit) then return end
     if not TRP3_API.globals.player_realm_id then return end
+    if issecretvalue(UnitGUID(unit)) or issecretvalue(UnitName(unit)) then return end
     local player = AddOn_TotalRP3 and AddOn_TotalRP3.Player and AddOn_TotalRP3.Player.CreateFromUnit(unit)
     if player then
         local color = player:GetCustomColorForDisplay()
@@ -105,11 +106,13 @@ end
 
 local function SetRPName(name, unit)
     if not TRP3_API.globals.player_realm_id then return end
-    local fullName = TRP3_API.r.name(unit) or ""
-    if issecretvalue(fullName) then
-        name:SetText(fullName)
+    local baseName = UnitName(unit)
+    local baseGUID = UnitGUID(unit)
+    if issecretvalue(baseName) or issecretvalue(baseGUID) then
+        name:SetText(baseName or "")
         return
     end
+    local fullName = TRP3_API.r.name(unit) or ""
     local firstRpName, lastRpName = fullName:match("^(%S+)%s*(.*)$")
 
     if rpNamesFirst and rpNamesLast then


### PR DESCRIPTION
secret values passed into certain trp3 functions causes errors in healthbarColor and nameFix (and they spam like crazy in instanced combat). this adds secret checks to prevent said errors and return early